### PR TITLE
fixes for es_update --newer

### DIFF
--- a/django_elastic_migrations/indexes.py
+++ b/django_elastic_migrations/indexes.py
@@ -588,7 +588,7 @@ class DEMDocType(ESDocType):
         for start_index in range(0, total_items, batch_size):
             # See https://docs.djangoproject.com/en/1.9/ref/models/querysets/#when-querysets-are-evaluated:
             # "slicing an unevaluated QuerySet returns another unevaluated QuerySet"
-            end_index = start_index + batch_size
+            end_index = min(start_index + batch_size, total_items - start_index)
             batch_qs = qs[start_index:end_index]
             try:
                 ids_in_batch = list(batch_qs.values_list(cls.PK_ATTRIBUTE, flat=True))

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -44,7 +44,7 @@ class Index(models.Model):
         """
         Get a string representation of this model instance.
         """
-        return '<Index, ID: {}>'.format(self.id)
+        return '<Index {}>'.format(self.name)
 
     def get_latest_version(self):
         """
@@ -145,7 +145,7 @@ class IndexVersion(models.Model):
         """
         Get a string representation of this model instance.
         """
-        return '<IndexVersion for {}, ID: {}>'.format(str(self.index), self.id)
+        return '<IndexVersion {}>'.format(self.name)
 
     @property
     def is_active(self):

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -912,6 +912,9 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
 
         doc_type = dem_index.doc_type()
 
+        if self.index_version:
+            self._index_version_name = self.index_version.name
+
         self._last_update = None
 
         if self.start_date:
@@ -924,7 +927,7 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
             if not self._last_update:
                 self._last_update = 'never'
             self.add_log(
-                "--resume detected; Checking the last time update was called: "
+                "--resume: checking the last time update was called succesfully and completed: "
                 u"\n - index version: {_index_version_name} "
                 u"\n - update date: {_last_update} ", use_self_dict_format=True
             )

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -341,6 +341,7 @@ class IndexAction(models.Model):
             )
             self.add_log(msg, level=logger.ERROR)
             self.to_aborted()
+            raise
 
     @classmethod
     def get_new_action(cls, index_name, include_active_version=False, action=None):

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -8,6 +8,7 @@ import random
 import sys
 import time
 import traceback
+from copy import deepcopy
 from multiprocessing import cpu_count
 
 from django.db import models, transaction
@@ -374,6 +375,21 @@ class IndexAction(models.Model):
                 parent.save()
         return parent_docs_affected
 
+    def check_child_statuses(self):
+        child_statuses = self.children.values_list('status', flat=True)
+        if all([c == IndexAction.STATUS_COMPLETE for c in child_statuses]):
+            self.add_log("All child tasks are completed successfully")
+        else:
+            self.add_log("NOT All child tasks are completed successfully:")
+            bad_children = list(self.children.exclude(status__in=IndexAction.STATUS_COMPLETE))
+            if bad_children:
+                err_logs = []
+                for bad_child in bad_children:
+                    err_logs.append("task id {} has status {}".format(bad_child.id, bad_child.status))
+                self.add_logs(err_logs)
+            else:
+                self.add_logs("No child tasks found! Please ensure there was work to be done.", level=logger.WARNING)
+
 
 """
 ↓ Action Mixins Below ↓
@@ -417,9 +433,19 @@ class GenericModeMixin(object):
                 mode_name=self.MODE_NAME
             ))
 
+        # make created child actions point back to the parent action
+        action.parent = self
+        action.index = self.index
+
         for version in versions:
             sub_dem_index = DEMIndexManager.get_dem_index(version.name, exact_mode=True)
+            action.index_version = version
+            action.pk = None
+            action.docs_affected = 0
+            action.save()
             action.start_action(dem_index=sub_dem_index)
+
+        self.check_child_statuses()
 
         self.add_log(
             " - Done applying action {action_name} to {num_index_versions} "
@@ -893,11 +919,31 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
         proxy = True
 
     def __init__(self, *args, **kwargs):
-        self.resume_mode = kwargs.pop('resume_mode', False)
-        # :param workers: number of workers to parallelize indexing
-        self.workers = kwargs.pop('workers', 0)
-        self.batch_size = kwargs.pop('batch_size', 0)
-        self.start_date = kwargs.pop('start_date', None)
+        # initially, self_kwargs contains the UpdateIndexAction-specific defaults
+        kwarg_defaults = {
+            'resume_mode': False,
+            # :param workers: number of workers to parallelize indexing
+            'workers': 0,
+            'batch_size': 0,
+            'start_date': None,
+        }
+        self.self_kwargs = {}
+        # loop through each expected kwarg, and fill in self.resume_mode, etc
+        # also, update self.self_kwargs with values different from defaults
+        # so as to record history and to be able to spawn children
+        # with the same self_kwargs (see self.prepare_action)
+        for kwarg_name, default_val in kwarg_defaults.items():
+            actual_val = kwargs.pop(kwarg_name, default_val)
+            setattr(self, kwarg_name, actual_val)
+            if actual_val != default_val:
+                setattr(self.self_kwargs, kwarg_name, actual_val)
+
+        if NewerModeMixin.MODE_NAME in kwargs:
+            self.self_kwargs[NewerModeMixin.MODE_NAME] = True
+
+        # retain a history of how this command was called
+        self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
+
         super(UpdateIndexAction, self).__init__(*args, **kwargs)
         self._batch_num = 0
         self._expected_remaining = 0
@@ -910,6 +956,27 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
 
     def perform_action(self, dem_index, *args, **kwargs):
         self.prepare_action(dem_index)
+
+        if self.newer_mode:
+            # child actions started in self.prepare_action() are now completed
+            self.refresh_from_db()
+
+            docs_affected = 0
+            indexes_affected = []
+            for child in self.children.all():
+                docs_affected += child.docs_affected
+                indexes_affected.append(child.index_version.name)
+            self.docs_affected = docs_affected
+            self._indexes_affected = ", ".join(indexes_affected)
+
+            self._index_name = self.index.name
+            self.add_log(
+                "Completed with es_update {_index_name} --newer. "
+                "\n - Total docs affected: {docs_affected}"
+                "\n - Indexes affected: {_indexes_affected}",
+                use_self_dict_format=True
+            )
+            return
 
         doc_type = dem_index.doc_type()
 
@@ -977,18 +1044,7 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
         self._indexed_docs = self._num_success + self._num_failed
         self.docs_affected = self._num_success
 
-        child_statuses = self.children.values_list('status', flat=True)
-        if all([c == IndexAction.STATUS_COMPLETE for c in child_statuses]):
-            self.add_log("All child tasks are completed successfully")
-        else:
-            bad_children = list(self.children.exclude(status__in=IndexAction.STATUS_COMPLETE))
-            if bad_children:
-                err_logs = []
-                for bad_child in bad_children:
-                    err_logs.append("task id {} has status {}".format(bad_child.id, bad_child.status))
-                self.add_logs(err_logs)
-            else:
-                self.add_logs("No child tasks found! Please ensure there was work to be done.", level=logger.WARNING)
+        self.check_child_statuses()
 
         self._runtime = timezone.now() - self.start
         self._docs_per_sec = self._indexed_docs / self._runtime.total_seconds()
@@ -1042,7 +1098,11 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
 
             if self.newer_mode:
                 versions = self.index.get_newer_versions(given_version=index_version)
-                self.apply_to_newer(versions, action=UpdateIndexAction())
+                kwargs = deepcopy(self.self_kwargs)
+                # we don't want child update index actions to also do 'newer' tasks
+                kwargs.pop(NewerModeMixin.MODE_NAME)
+                update_index_action = UpdateIndexAction(**kwargs)
+                self.apply_to_newer(versions, update_index_action)
             else:
                 self.index_version = index_version
                 self._index_version_name = index_version.name
@@ -1076,7 +1136,7 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
 
             if self.newer_mode:
                 versions = self.index.get_newer_versions(given_version=active_version)
-                self.apply_to_newer(versions, action=UpdateIndexAction())
+                self.apply_to_newer(versions, UpdateIndexAction())
                 # we're done, because the newer versions will get their own actions
                 return
 
@@ -1119,7 +1179,16 @@ class PartialUpdateIndexAction(UpdateIndexAction):
         self.task_kwargs = json.dumps(new_kwargs, sort_keys=True)
 
     def perform_action(self, dem_index, *args, **kwargs):
-
+        """
+        :param dem_index:
+        :type dem_index: django_elastic_migrations.indexes.DEMIndex
+        :param args:
+        :type args:
+        :param kwargs:
+        :type kwargs:
+        :return: either (numSuccess, numFailed) or None
+        :rtype: Union[Tuple[int, int], None]
+        """
         kwargs = json.loads(self.task_kwargs)
 
         self.prepare_action(dem_index)

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -23,13 +23,14 @@ class CommonDEMTestUtilsMixin(object):
         index_model = dem_index.get_index_model()
 
         version_model = dem_index.get_version_model()
-        self.assertIsNotNone(version_model)
+        expected_msg = "The {} index should have an active version.".format(index_name)
+        self.assertIsNotNone(version_model, expected_msg)
 
         available_version_ids = index_model.get_available_versions().values_list('id', flat=True)
-        expected_msg = "At test setup, the '{}' index should have {} available version(s)".format(index_name, expected_num_versions)
+        expected_msg = "The '{}' index should have {} available version(s)".format(index_name, expected_num_versions)
         self.assertEqual(len(available_version_ids), expected_num_versions, expected_msg)
 
-        expected_msg = "the {} index should already exist in elasticsearch.".format(version_model.name)
+        expected_msg = "The {} index should already exist in elasticsearch.".format(version_model.name)
         self.assertTrue(version_model.exists_in_es(), expected_msg)
 
         return index_model, version_model, dem_index
@@ -133,7 +134,7 @@ class TestEsCreateManagementCommand(CommonDEMTestUtilsMixin, DEMTestCase):
 
     fixtures = ['tests/tests_initial.json']
 
-    def test_basic_invocation_and_force_param(self):
+    def test_basic_invocation_and_force_flags(self):
         index_model, version_model, _ = self._check_basic_setup_and_get_models()
 
         call_command('es_create', index_model.name)
@@ -149,7 +150,7 @@ class TestEsCreateManagementCommand(CommonDEMTestUtilsMixin, DEMTestCase):
         expected_msg = "After es_create --force, the movies index should have two versions"
         self.assertEqual(len(available_version_ids), 2, expected_msg)
 
-    def test_all_and_force_params(self):
+    def test_all_and_force_flags(self):
         movies_index_model, _, __ = self._check_basic_setup_and_get_models("movies")
 
         new_index_name = "moviez"
@@ -170,7 +171,7 @@ class TestEsCreateManagementCommand(CommonDEMTestUtilsMixin, DEMTestCase):
                 expected_msg = "After es_create --all --force, the {} index should now have two versions".format(index_model_instance.name)
                 self.assertEqual(len(available_version_ids), 2, expected_msg)
 
-    def test_es_only(self):
+    def test_es_only_flag(self):
         """
         Test that ./manage.py es_create my_index --es-only checks
         if it does not exist in es, and if it does not exist it creates it


### PR DESCRIPTION
fixes: 
* #21 wrong batch update total using multiprocessing in 0.7.1  
* #23 KeyError _index_version_name in es_update --newer 

cosmetic changes: 
* `str(Index)` and `str(IndexVersion)` now include the index's name
* `es_update` wasn't tracking its task_kwargs until now

POTENTIALLY BREAKING CHANGE: 
* in `IndexAction.add_log()`, reraise any caught exception

tests added: 
* `TestEsUpdateManagementCommand.test_newer_flag()`
* added new assertion helpers in `CommonDEMTestUtilsMixin`:
  `check_num_available_versions()` and `check_last_index_actions()`