### PR TITLE
#39 es update start flag broken

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,17 @@
 Changelog
 ---------
 
+0.7.6 (2018-09-11)
+~~~~~~~~~~~~~~~~~~
+* fix `#36 es_update --start flag broken <https://github.com/HBS-HBX/django-elastic-migrations/issues/39>`_
+
 0.7.5 (2018-08-20)
 ~~~~~~~~~~~~~~~~~~
-* fix `#35 open multiprocessing log in context handler
-<https://github.com/HBS-HBX/django-elastic-migrations/issues/35>`_
+* fix `#35 open multiprocessing log in context handler <https://github.com/HBS-HBX/django-elastic-migrations/issues/35>`_
 
 0.7.4 (2018-08-15)
 ~~~~~~~~~~~~~~~~~~
-* fix `#33 error when nothing to resume using --resume
-<https://github.com/HBS-HBX/django-elastic-migrations/issues/33>`_
+* fix `#33 error when nothing to resume using --resume <https://github.com/HBS-HBX/django-elastic-migrations/issues/33>`_
 
 0.7.3 (2018-08-14)
 ~~~~~~~~~~~~~~~~~~

--- a/django_elastic_migrations/__init__.py
+++ b/django_elastic_migrations/__init__.py
@@ -10,7 +10,7 @@ import sys
 from django_elastic_migrations.utils import loading
 from django_elastic_migrations.utils.django_elastic_migrations_log import get_logger
 
-__version__ = '0.7.5'
+__version__ = '0.7.6'
 
 default_app_config = 'django_elastic_migrations.apps.DjangoElasticMigrationsConfig'  # pylint: disable=invalid-name
 

--- a/django_elastic_migrations/management/commands/es_update.py
+++ b/django_elastic_migrations/management/commands/es_update.py
@@ -47,7 +47,7 @@ class Command(ESCommand):
             "--start",
             dest="start_date",
             help="The start date for indexing. Can be any dateutil-parsable string;"
-                 " YYYY-MM-DDTHH:MM:SS is recommended to avoid confusion",
+                 "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS is recommended to avoid confusion",
         )
 
     def handle(self, *args, **options):

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -965,7 +965,14 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
         super(UpdateIndexAction, self).__init__(*args, **kwargs)
         if self.task_kwargs == '{}' and self.self_kwargs:
             # retain a history of how this command was called
-            self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
+            try:
+                self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
+            except TypeError as e:
+                if 'Object of type datetime is not JSON serializable' in str(e):
+                    for key, val in self.self_kwargs.items():
+                        if isinstance(val, datetime.date):
+                            self.self_kwargs[key] = str(val)
+                    self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
 
         self._batch_num = 0
         self._expected_remaining = 0

--- a/django_elastic_migrations/models.py
+++ b/django_elastic_migrations/models.py
@@ -957,7 +957,10 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
             actual_val = kwargs.pop(kwarg_name, default_val)
             setattr(self, kwarg_name, actual_val)
             if actual_val != default_val:
-                self.self_kwargs[kwarg_name] = actual_val
+                if kwarg_name == 'start_date':
+                    self.self_kwargs['start_date'] = str(actual_val)
+                else:
+                    self.self_kwargs[kwarg_name] = actual_val
 
         if NewerModeMixin.MODE_NAME in kwargs:
             self.self_kwargs[NewerModeMixin.MODE_NAME] = True
@@ -965,14 +968,7 @@ class UpdateIndexAction(NewerModeMixin, IndexAction):
         super(UpdateIndexAction, self).__init__(*args, **kwargs)
         if self.task_kwargs == '{}' and self.self_kwargs:
             # retain a history of how this command was called
-            try:
-                self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
-            except TypeError as e:
-                if 'Object of type datetime is not JSON serializable' in str(e):
-                    for key, val in self.self_kwargs.items():
-                        if isinstance(val, datetime.date):
-                            self.self_kwargs[key] = str(val)
-                    self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
+            self.task_kwargs = json.dumps(self.self_kwargs, sort_keys=True)
 
         self._batch_num = 0
         self._expected_remaining = 0


### PR DESCRIPTION
fixes this issue and adds one test  for `./manage.py es_update --start` as well.