### PR TITLE
Prevent installation on incompatible Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     ],
     zip_safe=False,
     keywords='Django Elasticsearch',
+    python_requires=">=3.6, <=4.0",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',


### PR DESCRIPTION
See https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=python_requires#new-and-changed-setup-keywords