### PR TITLE
Add user permissions for elastic search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
   - wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
   - echo "deb $ES_APT_URL stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list
   - sudo apt-get update && sudo apt-get install elasticsearch -y
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
   - sudo service elasticsearch start
 
 install: pip install -r requirements/travis.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       python: 3.6
 
 before_install:
-  - pip install --upgrade pip
+  - pip install pip==9.0.1
   # work around https://github.com/travis-ci/travis-ci/issues/8363
   - wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
   - echo "deb $ES_APT_URL stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list


### PR DESCRIPTION
Adding the proper user rights should solve the elastic search travits problems as seen [here](https://travis-ci.com/github/HBS-HBX/django-elastic-migrations/jobs/269273006)

/usr/share/elasticsearch/bin/elasticsearch-env: line 71: /etc/default/elasticsearch: Permission denied
The command "sudo service elasticsearch start" failed and exited with 1 during .