### PR TITLE
Update "Django>=1.8,<=2.2" to "Django>=1.8,<=3.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,6 @@ addons:
 
 matrix:
   include:
-    - env: TOX_ENV=py35-django110-es60 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
-      python: 3.5
-    - env: TOX_ENV=py35-django111-es60 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
-      python: 3.5
-    - env: TOX_ENV=py35-django20-es60 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
-      python: 3.5
-    - env: TOX_ENV=py35-django21-es60 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
-      python: 3.5
     - env: TOX_ENV=py36-django110-es61 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt
       python: 3.6
     - env: TOX_ENV=py36-django111-es61 ES_APT_URL=https://artifacts.elastic.co/packages/6.x/apt

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     install_requires=[
         # TBD: GH issue #3 includes support for elasticsearch-dsl>=6.2.0
-        "Django>=1.8,<=2.2.19", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
+        "Django>=1.8,<=3.1", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
         "multiprocessing-logging>=0.2.6"
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     install_requires=[
         # TBD: GH issue #3 includes support for elasticsearch-dsl>=6.2.0
-        "Django>=1.8,<=2.2", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
+        "Django>=1.8,<=2.2.12", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
         "multiprocessing-logging>=0.2.6"
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     include_package_data=True,
     install_requires=[
         # TBD: GH issue #3 includes support for elasticsearch-dsl>=6.2.0
-        "Django>=1.8,<=2.2.12", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
+        "Django>=1.8,<=2.2.19", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
         "multiprocessing-logging>=0.2.6"
     ],
     zip_safe=False,


### PR DESCRIPTION
Ass the pip is more strict we need to match this one with the project to not get this error

```
ERROR: Cannot install -r etc/requirements.txt (line 211) and Django==2.2.12 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested Django==2.2.12
    django-elastic-migrations 0.9.0 depends on Django<=2.2 and >=1.8
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```