### PR TITLE
Support Django 5.2.1 and elasticsearch-dsl 7.x

### DIFF
--- a/django_elastic_migrations/__init__.py
+++ b/django_elastic_migrations/__init__.py
@@ -8,7 +8,7 @@ import sys
 from django_elastic_migrations.utils import loading
 from django_elastic_migrations.utils.django_elastic_migrations_log import get_logger
 
-__version__ = '0.9.0'
+__version__ = '7.0.0a1'
 
 default_app_config = 'django_elastic_migrations.apps.DjangoElasticMigrationsConfig'  # pylint: disable=invalid-name
 

--- a/django_elastic_migrations/indexes.py
+++ b/django_elastic_migrations/indexes.py
@@ -7,7 +7,7 @@ import django
 from django.db import ProgrammingError
 from elasticsearch import TransportError
 from elasticsearch.helpers import expand_action, bulk
-from elasticsearch_dsl import Index as ESIndex, DocType as ESDocType, Q as ESQ, Search
+from elasticsearch_dsl import Index as ESIndex, Document as ESDocType, Q as ESQ, Search
 
 from django_elastic_migrations import es_client, environment_prefix, es_test_prefix, dem_index_paths, get_logger, codebase_id
 from django_elastic_migrations.exceptions import DEMIndexNotFound, DEMDocTypeRequiresGetReindexIterator, \

--- a/django_elastic_migrations/indexes.py
+++ b/django_elastic_migrations/indexes.py
@@ -885,7 +885,8 @@ class DEMIndex(ESIndex):
             if active_version_name and self.__doc_type._doc_type:
                 self.__doc_type._doc_type.index = active_version_name
 
-            return super(DEMIndex, self).doc_type(doc_type)
+            # Return the doc_type directly since newer elasticsearch-dsl versions don't have doc_type method
+            return self.__doc_type
         else:
             if self.get_version_id() and not self.__doc_type:
                 version_model = self.get_version_model()
@@ -893,7 +894,8 @@ class DEMIndex(ESIndex):
                 doc_type = self.__base_dem_index.doc_type()
                 doc_type_index_backup = doc_type._doc_type.index
                 doc_type._doc_type.index = version_model.name
-                self.__doc_type = super(DEMIndex, self).doc_type(doc_type)
+                # Use doc_type directly since newer elasticsearch-dsl versions don't have doc_type method
+                self.__doc_type = doc_type
                 if not self.hash_matches(version_model.json_md5):
                     doc_type._doc_type.index = doc_type_index_backup
                     our_hash, our_json = self.get_index_hash_and_json()

--- a/setup.py
+++ b/setup.py
@@ -49,13 +49,13 @@ setup(
     license='MIT',
     include_package_data=True,
     install_requires=[
-        # TBD: GH issue #3 includes support for elasticsearch-dsl>=6.2.0
-        "Django>=1.8", "elasticsearch-dsl>=6.0.0,<6.2.0", "texttable>=1.2.1",
+        # Updated to support Django 5.2.1 and elasticsearch-dsl 7.x
+        "Django>=1.8", "elasticsearch-dsl>=7.0.0,<8.0.0", "texttable>=1.2.1",
         "multiprocessing-logging>=0.2.6"
     ],
     zip_safe=False,
     keywords='Django Elasticsearch',
-    python_requires=">=3.6, <=4.0",
+    python_requires=">=3.8, <4.0",
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
@@ -63,10 +63,23 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
- Update setup.py dependencies to elasticsearch-dsl>=7.0.0,<8.0.0
- Add Django 5.x classifiers and Python 3.12 support
- Fix DocType import (replaced with Document for elasticsearch-dsl 7.x)
- Bump version to 7.0.0a1